### PR TITLE
2016.2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.0.43"
+    id "org.jetbrains.intellij" version "0.1.10"
 }
 
 group = 'org.forgerock.cuppa'
@@ -29,7 +29,7 @@ checkstyle {
 }
 
 intellij {
-    version '2016.1'
+    version '2016.2'
     pluginName 'Cuppa'
 }
 


### PR DESCRIPTION
The plugin can't be installed onto 2016.2 without this small change. Tested on IntelliJ community edition 2016.2.5 on Linux.